### PR TITLE
Use Parallel instead of PMap

### DIFF
--- a/gemirro.gemspec
+++ b/gemirro.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'builder', '~>3.2'
   s.add_dependency 'sinatra', '~>1.4'
   s.add_dependency 'thin', '~>1.6'
-  s.add_dependency 'pmap', '~>1.0'
+  s.add_dependency 'parallel', '~>1.12'
 
   s.add_development_dependency 'rake', '~>10.4'
   s.add_development_dependency 'rack-test', '~>0.6'

--- a/lib/gemirro.rb
+++ b/lib/gemirro.rb
@@ -11,7 +11,7 @@ require 'httpclient'
 require 'logger'
 require 'stringio'
 require 'json'
-require 'pmap'
+require 'parallel'
 require 'tempfile'
 
 unless $LOAD_PATH.include?(File.expand_path('../', __FILE__))

--- a/lib/gemirro/server.rb
+++ b/lib/gemirro/server.rb
@@ -190,7 +190,7 @@ module Gemirro
     #
     def query_gems_list
       Utils.gems_collection(false) # load collection
-      gems = query_gems.pmap do |query_gem|
+      gems = Parallel.map(query_gems) do |query_gem|
         gem_dependencies(query_gem)
       end
 
@@ -214,19 +214,19 @@ module Gemirro
 
         return '' if gem_collection.nil?
 
-        gem_collection = gem_collection.pmap do |gem|
+        gem_collection = Parallel.map(gem_collection) do |gem|
           [gem, spec_for(gem.name, gem.number, gem.platform)]
         end
         gem_collection.reject! do |_, spec|
           spec.nil?
         end
 
-        gem_collection.pmap do |gem, spec|
+        Parallel.map(gem_collection) do |gem, spec|
           dependencies = spec.dependencies.select do |d|
             d.type == :runtime
           end
 
-          dependencies = dependencies.pmap do |d|
+          dependencies = Parallel.map(dependencies) do |d|
             [d.name.is_a?(Array) ? d.name.first : d.name, d.requirement.to_s]
           end
 

--- a/lib/gemirro/utils.rb
+++ b/lib/gemirro/utils.rb
@@ -43,7 +43,7 @@ module Gemirro
 
       file_paths = specs_files_paths(orig)
       has_file_changed = false
-      file_paths.pmap do |file_path|
+      Parallel.map(file_paths) do |file_path|
         next if data[:files].key?(file_path) &&
                 data[:files][file_path] == File.mtime(file_path)
         has_file_changed = true
@@ -53,7 +53,7 @@ module Gemirro
       return @gems_collection[is_orig][:values] unless has_file_changed
 
       gems = []
-      file_paths.pmap do |file_path|
+      Parallel.map(file_paths) do |file_path|
         next unless File.exist?(file_path)
         gems.concat(Marshal.load(Zlib::GzipReader.open(file_path).read))
         data[:files][file_path] = File.mtime(file_path)
@@ -73,7 +73,7 @@ module Gemirro
     #
     def self.specs_files_paths(orig = true)
       marshal_version = Gemirro::Configuration.marshal_version
-      specs_file_types.pmap do |specs_file_type|
+      Parallel.map(specs_file_types) do |specs_file_type|
         File.join(configuration.destination,
                   [specs_file_type,
                    marshal_version,

--- a/spec/gemirro/server_spec.rb
+++ b/spec/gemirro/server_spec.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 require 'rack/test'
 require 'json'
-require 'pmap'
+require 'parallel'
 require 'gemirro/cache'
 require 'gemirro/utils'
 require 'gemirro/mirror_directory'


### PR DESCRIPTION
Use Parallel (https://github.com/grosser/parallel) instead of PMap (https://github.com/bruceadams/pmap) for parallel processing.

PMap hasn't been updated in over a year and appears to be causing issues for users: https://github.com/PierreRambaud/gemirro/issues/47