### PR TITLE
Changed URI Escape to use CGI.escape

### DIFF
--- a/lib/gemirro/server.rb
+++ b/lib/gemirro/server.rb
@@ -1,6 +1,5 @@
 require 'sinatra/base'
 require 'thin'
-require 'CGI'
 
 module Gemirro
   ##

--- a/lib/gemirro/server.rb
+++ b/lib/gemirro/server.rb
@@ -280,7 +280,7 @@ module Gemirro
       # @return [String]
       #
       def homepage(spec)
-        URI.parse(CGI.escape(spec.homepage)) 
+        URI.parse(CGI.escape(spec.homepage))
       end
     end
   end

--- a/lib/gemirro/server.rb
+++ b/lib/gemirro/server.rb
@@ -1,6 +1,6 @@
 require 'sinatra/base'
 require 'thin'
-require 'uri'
+require 'CGI'
 
 module Gemirro
   ##
@@ -280,7 +280,7 @@ module Gemirro
       # @return [String]
       #
       def homepage(spec)
-        URI.parse(URI.escape(spec.homepage))
+        URI.parse(CGI.escape(spec.homepage)) 
       end
     end
   end


### PR DESCRIPTION
This will fix Rubocop complaining on Travis CI builds.

Functionality between URI.escape and CGI.escape is extremely close.

Rspec and Rubocop both pass.