### PR TITLE
Allow process daemonization to be controlled by configuration

### DIFF
--- a/lib/gemirro/cli/server.rb
+++ b/lib/gemirro/cli/server.rb
@@ -70,7 +70,7 @@ Gemirro::CLI.options.command 'server' do
       end
     end
 
-    Process.daemon
+    Process.daemon if Utils.configuration.server.daemonize
     create_pid
     STDOUT.reopen @orig_stdout
     puts "done! (PID is #{pid})\n"

--- a/lib/gemirro/configuration.rb
+++ b/lib/gemirro/configuration.rb
@@ -7,7 +7,8 @@ module Gemirro
     default_config = {
       server: {
         access_log: '/tmp/gemirro.access.log',
-        error_log: '/tmp/gemirro.access.log'
+        error_log: '/tmp/gemirro.access.log',
+        daemonize: true
       },
 
       update_on_fetch: true,

--- a/template/config.rb
+++ b/template/config.rb
@@ -17,6 +17,9 @@ Gemirro.configuration.configure do
   #
   # server.host 'localhost'
   # server.port '2000'
+
+  # If you don't want the server to run daemonized, uncomment the following
+  # server.daemonize false
   server.access_log File.expand_path('../logs/access.log', __FILE__)
   server.error_log File.expand_path('../logs/error.log', __FILE__)
 


### PR DESCRIPTION
This allows config.rb to define server.daemonize to manage whether
the server process daemonizes.  The current fixed behavior to
damonize hinders the ability to run gemirro with docker compose.