### PR TITLE
update ignore specs to also look for not ignored platforms

### DIFF
--- a/spec/gemirro/configuration_spec.rb
+++ b/spec/gemirro/configuration_spec.rb
@@ -72,6 +72,7 @@ module Gemirro
       expect(@config.ignore_gem('rake', '1.0.0', 'ruby')).to eq(['1.0.0'])
       expect(@config.ignored_gems).to eq('ruby' => {'rake' => ['1.0.0']})
       expect(@config.ignore_gem?('rake', '1.0.0', 'ruby')).to be_truthy
+      expect(@config.ignore_gem?('rake', '1.0.0', 'java')).to be_falsy
     end
 
     it 'should add and return source' do

--- a/spec/gemirro/gems_fetcher_spec.rb
+++ b/spec/gemirro/gems_fetcher_spec.rb
@@ -37,6 +37,7 @@ module Gemirro
       expect(@fetcher.ignore_gem?('gemirro', '0.0.1', 'ruby')).to be_falsy
       Utils.configuration.ignore_gem('gemirro', '0.0.1', 'ruby')
       expect(@fetcher.ignore_gem?('gemirro', '0.0.1', 'ruby')).to be_truthy
+      expect(@fetcher.ignore_gem?('gemirro', '0.0.1', 'java')).to be_falsy
     end
 
     it 'should log error when fetch gem failed' do


### PR DESCRIPTION
the addition of "platform" to the gem ignore logic did not add tests for the case the change should fix: platformA is ignored while platformB isn't (yet).

this commit adds the relevant tests so that after the gem for "ruby" was downloaded/ignored, the same version for "java" is still not ignored