### PR TITLE
change default define_source `http://rubygems.org` -> `https://rubygems.org`

### DIFF
--- a/spec/gemirro/server_spec.rb
+++ b/spec/gemirro/server_spec.rb
@@ -166,7 +166,7 @@ module Gemirro
       end
 
       it 'should catch exceptions' do
-        source = Gemirro::Source.new('test', 'http://rubygems.org')
+        source = Gemirro::Source.new('test', 'https://rubygems.org')
 
         versions_fetcher = Gemirro::VersionsFetcher.new(source)
         allow(versions_fetcher).to receive(:fetch).once.and_return(true)

--- a/template/config.rb
+++ b/template/config.rb
@@ -35,7 +35,7 @@ Gemirro.configuration.configure do
   # You must define a source which where gems will be downloaded.
   # All gem in the block will be downloaded with the update command.
   # Other gems will be downloaded with the server.
-  define_source 'rubygems', 'http://rubygems.org' do
+  define_source 'rubygems', 'https://rubygems.org' do
     gem 'rack', '>= 1.0.0'
   end
 end


### PR DESCRIPTION
Handle network connection more secure.